### PR TITLE
Rename into InputParameters

### DIFF
--- a/src/oauth2/provider.rs
+++ b/src/oauth2/provider.rs
@@ -12,14 +12,19 @@ pub struct SmtpPort(pub u16);
 pub struct ProfileUrl(pub Url);
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Provider {
+pub struct InputParameters {
     pub process: String,
     pub provider: String,
-    pub authorization_endpoint: AuthUrl,
-    pub token_endpoint: TokenUrl,
-    pub device_auth_endpoint: DeviceAuthorizationUrl,
-    pub scopes: Vec<Scope>,
-    pub client_id: ClientId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorization_endpoint: Option<AuthUrl>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_endpoint: Option<TokenUrl>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_auth_endpoint: Option<DeviceAuthorizationUrl>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scopes: Option<Vec<Scope>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<ClientId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_secret: Option<ClientSecret>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/oauth2/provider.rs
+++ b/src/oauth2/provider.rs
@@ -13,8 +13,10 @@ pub struct ProfileUrl(pub Url);
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InputParameters {
-    pub process: String,
-    pub provider: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authorization_endpoint: Option<AuthUrl>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/oauth2/tests/login.rs
+++ b/src/oauth2/tests/login.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use crate::oauth2::device_code_flow::login;
-use crate::oauth2::provider::Provider;
+use crate::oauth2::provider::InputParameters;
 use crate::task_manager::{TaskManager, TaskMessage};
 use crate::{interface::mock::Mock, setup_logger};
 
@@ -9,23 +9,23 @@ use http::{HeaderMap, HeaderValue, Response, StatusCode};
 use oauth2::{url::Url, AuthUrl, ClientId, DeviceAuthorizationUrl, Scope, TokenUrl};
 use tokio::sync::mpsc::unbounded_channel;
 
-fn build_mock_provider() -> Provider {
-    Provider {
-        authorization_endpoint: AuthUrl::from_url(
+fn build_mock_provider() -> InputParameters {
+    InputParameters {
+        authorization_endpoint: Some(AuthUrl::from_url(
             Url::parse("https://login.microsoftonline.com/common/oauth2/v2.0/authorize").unwrap(),
-        ),
-        token_endpoint: TokenUrl::from_url(
+        )),
+        token_endpoint: Some(TokenUrl::from_url(
             Url::parse("https://login.microsoftonline.com/common/oauth2/v2.0/token").unwrap(),
-        ),
-        device_auth_endpoint: DeviceAuthorizationUrl::from_url(
+        )),
+        device_auth_endpoint: Some(DeviceAuthorizationUrl::from_url(
             Url::parse("https://login.microsoftonline.com/common/oauth2/v2.0/devicecode").unwrap(),
-        ),
-        scopes: vec![
+        )),
+        scopes: Some(vec![
             Scope::new("offline_access".into()),
             Scope::new("https://outlook.office.com/SMTP.Send".into()),
             Scope::new("https://outlook.office.com/User.Read".into()),
-        ],
-        client_id: ClientId::new("64c5d510-4b7e-4a18-8869-89778461c266".into()),
+        ]),
+        client_id: Some(ClientId::new("64c5d510-4b7e-4a18-8869-89778461c266".into())),
         client_secret: None,
         process: String::from("Process Name"),
         provider: String::from("Microsoft"),

--- a/src/oauth2/tests/login.rs
+++ b/src/oauth2/tests/login.rs
@@ -27,8 +27,8 @@ fn build_mock_provider() -> InputParameters {
         ]),
         client_id: Some(ClientId::new("64c5d510-4b7e-4a18-8869-89778461c266".into())),
         client_secret: None,
-        process: String::from("Process Name"),
-        provider: String::from("Microsoft"),
+        process: Some(String::from("Process Name")),
+        provider: Some(String::from("Microsoft")),
         id_token: None,
     }
 }

--- a/src/shared_object.rs
+++ b/src/shared_object.rs
@@ -8,7 +8,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::interface::Interface;
 use crate::oauth2::device_code_flow::{self};
 use crate::oauth2::error::{ErrorCodes, OAuth2Error};
-use crate::oauth2::provider::Provider;
+use crate::oauth2::provider::InputParameters;
 use crate::openid::{self, ApplicationNonce};
 use crate::task_manager::TaskMessage;
 
@@ -37,7 +37,7 @@ where
     async fn call(&self, method: &str, args: &Value) -> Value {
         log::trace!("Method: {} Param: {:?}", method, args);
 
-        let param: Provider = match serde_json::from_value(args.clone()) {
+        let param: InputParameters = match serde_json::from_value(args.clone()) {
             Ok(p) => p,
             Err(e) => {
                 let e = OAuth2Error::from(e);


### PR DESCRIPTION
We make the other field optional since
it depend on the method that caller will be using.

Having this will have uniform parameter from the remote caller.